### PR TITLE
Implementing support of groupping areas and highlight them as single element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .sass-cache
+.idea
 node_modules


### PR DESCRIPTION
Hi, I've managed to implement group areas issue we discussed recently https://github.com/etienne-martin/mapify/issues/10 

If you are interested , please check out this pull request.

I've added default option grouppingDataKey: '' which keeps mapify working the way it worked before, only if you pass some sensible value like 
grouppingDataKey: 'sectorId'
and mark appropriate areas with common sector id data key
`
<area data-sector-id='2'> ``
<area data-sector-id='2'>
<area data-sector-id='3'>
`
then mapify will highlight areas with the same sectorId.

I moved drawHilight contents to highlightSingleArea method without any changes



